### PR TITLE
feat: implement setHidable and default toggle caption to header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<description>Grid Helpers Add-on for Vaadin Flow</description>
 
 	<properties>
-		<vaadin.version>22.0.9</vaadin.version>
+		<vaadin.version>22.0.17</vaadin.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelper.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelper.java
@@ -239,8 +239,26 @@ public final class GridHelper<T> implements Serializable {
     return getHelper(grid).columnToggleHelper.isColumnToggleVisible();
   }
 
+  /**Returns whether this column can be hidden by the user. Default is {@code false}.
+   * 
+   * @return {@code true} if the user can hide the column, {@code false} if not.*/
+  public static <T> boolean isHidable(Column<T> column) {
+    return getHelper(column.getGrid()).columnToggleHelper.isHidable(column);
+  }
+
+  /**Sets whether this column can be hidden by the user. Hidable columns can be hidden and shown via the sidebar menu.
+   * @param column the column to be configured
+   * @param hidable {@code true} if the column may be hidden by the user via UI interaction
+   * 
+   * @return the column.
+   */
+  public static <T> Column<T> setHidable(Column<T> column, boolean hidable) {
+    getHelper(column.getGrid()).columnToggleHelper.setHidable(column, hidable);
+    return column;
+  }
+  
   /**
-   * Sets the caption of the hiding toggle for this column.
+   * Sets the caption of the hiding toggle for this column. Shown in the toggle for this column in the grid's sidebar when the column is {@linkplain #isHidable(Column) hidable}.
    *
    * <p>If the value is <code>null</code>, the column cannot be hidden via the sidebar menu.
    *

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/AllFeaturesDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/AllFeaturesDemo.java
@@ -60,25 +60,25 @@ public class AllFeaturesDemo extends Div {
 
     Grid<Person> grid = new Grid<>();
 
-    grid.addColumn(Person::getLastName).setHeader("Last name").setHidingToggleCaption("Last name");
+    grid.addColumn(Person::getLastName).setHeader("Last name").setHidingToggleCaption("Last name column");
     grid.addColumn(Person::getFirstName)
         .setHeader("First name")
-        .setHidingToggleCaption("First name");
+        .setHidingToggleCaption("First name column");
     grid.addColumn(p -> p.isActive() ? "Yes" : "No")
         .setHeader("Active")
-        .setHidingToggleCaption("Active");
-    grid.addColumn(Person::getTitle).setHeader("Title").setHidingToggleCaption("Title");
-    grid.addColumn(Person::getCountry).setHeader("Country").setHidingToggleCaption("Country");
-    grid.addColumn(Person::getCity).setHeader("City").setHidingToggleCaption("City");
+        .setHidable(true);
+    grid.addColumn(Person::getTitle).setHeader("Title").setHidable(true);
+    grid.addColumn(Person::getCountry).setHeader("Country").setHidable(true);
+    grid.addColumn(Person::getCity).setHeader("City").setHidable(true);
     grid.addColumn(Person::getStreetAddress)
         .setHeader("Street Address")
-        .setHidingToggleCaption("Street Address");
+        .setHidable(true);
     grid.addColumn(Person::getPhoneNumber)
         .setHeader("Phone Number")
-        .setHidingToggleCaption("Phone Number");
+        .setHidable(true);
     grid.addColumn(Person::getEmailAddress)
         .setHeader("Email Address")
-        .setHidingToggleCaption("Email Address");
+        .setHidable(true);
     grid.getColumns().forEach(c -> c.setAutoWidth(true));
 
     grid.setItems(TestData.initializeData());


### PR DESCRIPTION
Now that `getHeader` is implemented, we can default the toggle caption to the header caption as in [Vaadin 8](https://vaadin.com/api/framework/8.16.0/com/vaadin/ui/Grid.Column.html#setHidingToggleCaption-java.lang.String-)