### PR TITLE
build: restore vaadin version to 22.0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<description>Grid Helpers Add-on for Vaadin Flow</description>
 
 	<properties>
-		<vaadin.version>23.2.6</vaadin.version>
+		<vaadin.version>22.0.17</vaadin.version>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
By mistake I commited an upgrade to the vaadin version in #38.
It was not intended: the addon remains compatible with Vaadin 22+
