### PR TITLE
fix: Keep original selection when clicking a non-selectable row

### DIFF
--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/GridHelperElement.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/GridHelperElement.java
@@ -13,7 +13,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 
-public class GridHelperElement extends GridElement {
+public class GridHelperElement extends MyGridElement {
 
   public GridHelperElement(GridElement e) {
     init(e.getWrappedElement(), e.getCommandExecutor());

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/MyGridElement.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/MyGridElement.java
@@ -1,0 +1,34 @@
+package com.flowingcode.vaadin.addons.gridhelpers.it;
+
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import com.vaadin.flow.component.grid.testbench.GridTRElement;
+import com.vaadin.testbench.TestBenchElement;
+
+/*
+ * Workaround for bug https://github.com/vaadin/flow-components/issues/1598
+ */
+public class MyGridElement extends GridElement {
+
+  @Override
+  public void select(int rowIndex) {
+    if (isMultiselect()) {
+      // call @ClientCallable Grid.select() on server-side which will fire the selection event.
+      GridTRElement row = getRow(rowIndex);
+      executeScript("arguments[0].$server.select(arguments[1]._item.key)", this, row);
+    } else {
+      super.select(rowIndex);
+    }
+  }
+
+  private boolean isMultiselect() {
+    return (boolean) executeScript(
+        "return arguments[0]._getColumns().filter(function(col) { return typeof col.selectAll != 'undefined';}).length > 0",
+        this);
+  }
+
+  public void deselectAll() {
+    TestBenchElement selectionCol = $("vaadin-grid-flow-selection-column").first();
+    executeScript("arguments[0].$server.deselectAll()", selectionCol);
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/SelectionFilterIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/SelectionFilterIT.java
@@ -21,11 +21,9 @@
 package com.flowingcode.vaadin.addons.gridhelpers.it;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import com.flowingcode.vaadin.testbench.rpc.HasRpcSupport;
 import com.flowingcode.vaadin.testbench.rpc.JsonArrayList;
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
-import com.vaadin.flow.component.grid.testbench.GridElement;
 import java.util.Arrays;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -43,7 +41,7 @@ public class SelectionFilterIT extends AbstractViewTest implements HasRpcSupport
   @Override
   public void setup() throws Exception {
 	super.setup();
-	grid = new GridHelperElement($(GridElement.class).waitForFirst());
+	grid = new GridHelperElement($(MyGridElement.class).waitForFirst());
   }
 
   @SafeVarargs
@@ -75,9 +73,8 @@ public class SelectionFilterIT extends AbstractViewTest implements HasRpcSupport
 
     // odd items cannot be selected
     grid.select(1);
-    // TODO should it be cleared?
-    // assertThat($server.getSelectedRows(), equalToList(0));
-    assertThat($server.getSelectedRows(), empty());
+    // original selection is preserved
+    assertThat($server.getSelectedRows(), equalToList(0));
 
     grid.select(2);
     assertThat($server.getSelectedRows(), equalToList(2));


### PR DESCRIPTION
When Grid has single selection mode enabled, clicking a non-selectable row must restore the previous selection

Close #40