### PR TITLE
Height by rows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -526,6 +526,7 @@
 				<maven.compiler.target>17</maven.compiler.target>
 				<vaadin.version>24.0.5</vaadin.version>
 				<jetty.version>11.0.12</jetty.version>
+				<frontend.hotdeploy>true</frontend.hotdeploy>
 			</properties>
 		</profile>
 		

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,12 @@
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
 			<version>3.8.1</version>
-			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.jsoup</groupId>
+					<artifactId>jsoup</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>		
 		<dependency>
     		<groupId>com.github.javafaker</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,12 @@
 							<resourceBase>src/main/resources/META-INF/resources</resourceBase>
 						</resourceBases>
 					</webAppConfig>
+					<webApp>
+						<resourceBases>
+							<resourceBase>src/test/resources/META-INF/resources</resourceBase>
+							<resourceBase>src/main/resources/META-INF/resources</resourceBase>
+						</resourceBases>
+					</webApp>
 					<supportedPackagings>
 						<supportedPackaging>jar</supportedPackaging>
 					</supportedPackagings>

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelper.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelper.java
@@ -435,4 +435,81 @@ public final class GridHelper<T> implements Serializable {
     return getHelper(grid).headerFooterStylesHelper.getStyles(cell);
   }
 
+
+  private final HeightByRowsHelper heightByRowsHelper = new HeightByRowsHelper(this);
+
+  /**
+   * Sets the number of rows that should be visible in Grid's body.
+   *
+   * The algorithm assumes that all data rows have the same height and considers headers, footers,
+   * and the horizontal scrollbar when the method is called. However, if data rows, headers, or
+   * footers are inserted or removed after the initial calculation, the grid may not automatically
+   * adjust the size of the grid to accommodate the changed number of rows.
+   *
+   * @param rows The height in terms of number of rows displayed in Grid's body. If Grid doesn't
+   *        contain enough rows, white space is displayed instead.
+   * @throws IllegalArgumentException if {@code rows} is zero or less
+   * @throws IllegalArgumentException if {@code rows} is {@link Double#isInfinite(double) infinite}
+   * @throws IllegalArgumentException if {@code rows} is {@link Double#isNaN(double) NaN}
+   */
+  public static void setHeightByRows(Grid<?> grid, double rows) {
+    getHelper(grid).heightByRowsHelper.setHeightByRows(rows);
+  }
+
+  /**
+   * Sets the number of rows that should be visible in Grid's body, while
+   * {@link #getHeightMode()} is {@link HeightMode#ROW}.
+   * <p>
+   * If Grid is currently not in {@link HeightMode#ROW}, the given value is
+   * remembered, and applied once the mode is applied.
+   *
+   * @See {@link #setHeightByRows(Grid, double)}
+   */
+  public static void setHeightByRows(Grid<?> grid, int rows) {
+    // this overload is a workaround for a lombok issue "bad type on operand stack"
+    // when setHeightByRows(Grid, double) is called with actual parameter of type int
+    setHeightByRows(grid, (double) rows);
+  }
+
+  /**
+   * Gets the amount of rows in Grid's body that are shown,
+   * while {@link #getHeightMode()} is {@link HeightMode#ROW}.
+   *
+   * @return the amount of rows that are being shown in Grid's body
+   * @see #setHeightByRows(double)
+   */
+  public static double getHeightByRows(Grid<?> grid) {
+    return getHelper(grid).heightByRowsHelper.getHeightByRows();
+  }
+
+  /**
+   * Defines the mode in which the Grid's height is calculated.
+   * <p>
+   * If {@link HeightMode#CSS} is given, Grid will respect the values given via a
+   * {@code setHeight}-method, and behave as a traditional Component.
+   * <p>
+   * If {@link HeightMode#ROW} is given, Grid will make sure that the body will display as many rows
+   * as {@link #getHeightByRows()} defines.
+   *
+   * @param heightMode the mode in to which Grid should be set
+   */
+  public static void setHeightMode(Grid<?> grid, HeightMode heightMode) {
+    getHelper(grid).heightByRowsHelper.setHeightMode(heightMode);
+  }
+
+  /**
+   * Defines the mode in which the Grid's height is calculated.
+   * <p>
+   * If {@link HeightMode#CSS} is given, Grid will respect the CSS height as a traditional Component.
+   * <p>
+   * If {@link HeightMode#ROW} is given, Grid will make sure that the body will display as many rows
+   * as {@link #getHeightByRows()} defines.
+   *
+   * @param heightMode the mode in to which Grid should be set
+   * @return
+   */
+  public static HeightMode getHeightMode(Grid<?> grid) {
+    return getHelper(grid).heightByRowsHelper.getHeightMode();
+  }
+
 }

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/HeightByRowsHelper.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/HeightByRowsHelper.java
@@ -1,0 +1,60 @@
+package com.flowingcode.vaadin.addons.gridhelpers;
+
+import java.io.Serializable;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@SuppressWarnings("serial")
+@RequiredArgsConstructor
+class HeightByRowsHelper implements Serializable {
+
+  private static final String THEME = "height-by-rows";
+
+  private final GridHelper<?> helper;
+
+  @Getter
+  private double heightByRows;
+
+  private HeightMode heightMode;
+
+  void setHeightByRows(double rows) {
+    if (rows <= 0.0d) {
+      throw new IllegalArgumentException("More than zero rows must be shown.");
+    } else if (Double.isInfinite(rows)) {
+      throw new IllegalArgumentException("Grid doesn't support infinite heights");
+    } else if (Double.isNaN(rows)) {
+      throw new IllegalArgumentException("NaN is not a valid row count");
+    }
+
+    heightByRows = rows;
+
+    if (heightMode == HeightMode.ROW) {
+      helper.getGrid().getElement().executeJs("this.fcGridHelper.setHeightByRows($0)", rows);
+      helper.getGrid().setThemeName(THEME, heightMode == HeightMode.ROW);
+    }
+  }
+
+  void setHeightMode(HeightMode heightMode) {
+    if (this.heightMode == null) {
+      helper.getGrid().addAttachListener(ev -> {
+        if (heightMode == HeightMode.ROW) {
+          setHeightByRows(heightByRows);
+        }
+      });
+    }
+
+    this.heightMode = heightMode;
+    if (heightMode == HeightMode.ROW && heightByRows != 0) {
+      setHeightByRows(heightByRows);
+      helper.getGrid().addThemeName(THEME);
+    } else {
+      helper.getGrid().removeThemeName(THEME);
+    }
+  }
+
+  HeightMode getHeightMode() {
+    return Optional.ofNullable(heightMode).orElse(HeightMode.CSS);
+  }
+
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/HeightMode.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/HeightMode.java
@@ -1,0 +1,20 @@
+package com.flowingcode.vaadin.addons.gridhelpers;
+
+/**
+ * The modes for height calculation that are supported {@link GridHelper}.
+ *
+ * @see GridHelper#setHeightMode(HeightMode)
+ */
+public enum HeightMode {
+  /**
+   * 
+   * The height of the Component is defined by a CSS-like value.
+   */
+  CSS,
+
+  /**
+   * The height of the Component is defined by a number of rows.
+   */
+  ROW;
+}
+

--- a/src/main/resources/META-INF/frontend/fcGridHelper/connector.js
+++ b/src/main/resources/META-INF/frontend/fcGridHelper/connector.js
@@ -29,6 +29,7 @@ import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 (function () { 
   window.Vaadin.Flow.fcGridHelperConnector = {
     initLazy: grid => {
+    
     	//https://cookbook.vaadin.com/grid-arrow-selection
     	grid.addEventListener('keyup', function(e) {
     		if (e.keyCode == 32) return;
@@ -51,6 +52,38 @@ import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 			});
 		}.bind(grid);
 
+		grid.fcGridHelper = {
+			setHeightByRows : function(n) {
+				var height = grid.fcGridHelper.computeHeightByRows(n);
+				grid.style.setProperty('--height-by-rows',height+'px');
+			},
+			
+			computeHeightByRows : function(n) {
+				var height = 0;
+				var rows = grid.shadowRoot.querySelectorAll("tbody tr");
+				for(var i=0;i<n && i<rows.length;i++) {
+					height += rows[i].offsetHeight;
+				}
+				
+				if (rows.length<n) {
+				  height *= n/rows.length;
+				}
+				
+				height += grid.shadowRoot.querySelector("thead").offsetHeight;
+				height += grid.shadowRoot.querySelector("tfoot").offsetHeight;
+				
+				var table = grid.shadowRoot.querySelector("table");
+				
+				var clientHeight = table.clientHeight;
+				table.style.overflowX = 'hidden';
+				height += table.clientHeight - clientHeight;
+				table.style.overflowX = '';
+				
+				return height;
+			},
+			
+		};
     }
+	
   }
 })();

--- a/src/main/resources/META-INF/frontend/fcGridHelper/vaadin-grid.css
+++ b/src/main/resources/META-INF/frontend/fcGridHelper/vaadin-grid.css
@@ -64,3 +64,8 @@ table[aria-multiselectable="true"] .fcGh-noselect[first-column] ::slotted(*) {
 :host([theme~="fcGh-hide-footers"]) #footer {
 	display: none;
 }
+
+:host([theme~="height-by-rows"]) {
+	height : var(--height-by-rows);
+	max-height : var(--height-by-rows);
+}

--- a/src/test/resources/META-INF/resources/gridhelpers/gridhelpers-demo.js
+++ b/src/test/resources/META-INF/resources/gridhelpers/gridhelpers-demo.js
@@ -1,0 +1,19 @@
+(function(){
+  window.Vaadin.Flow.fcGridHelperDemoConnector = {
+	
+	getViewportRowCount : grid => {
+		//bisection method, f is monotonically increasing 
+		var f= x=>grid.fcGridHelper.computeHeightByRows(x) - grid.clientHeight;
+		var a=1,b=1;
+		if (f(a)>=0) return 1;
+		while (f(b)<0) fb=f(b+=b);
+		var find = (a,b) => {
+			var m=Math.ceil((a+b)/2), fm=f(m);
+			if (fm==0 || b-a<=2) return (fm>0) ? m-1 : m;
+			return fm>0 ? find(a,m) : find(m,b);
+		} 
+		return find(a,b);
+	}		
+		
+  }
+})();


### PR DESCRIPTION
Add support for Vaadin 8 style "setHeightByRows". The algorithm assumes that all data rows have the same height and considers headers, footers, and the horizontal scrollbar when the method is called. However, if data rows, headers, or footers are inserted or removed after the initial calculation, the grid may not automatically adjust the size of the grid to accommodate the changed number of rows.

This contribution contains Personal Intellectual Property that is and remains owned by its Author. Contingent upon the acceptance of this contribution, Flowing Code will be granted a non-exclusive, irrevocable and transferable license, to the fullest extent possible, under the terms stated in the Agreement on Intellectual Property in effect.


