### PR TITLE
test: fix integration test in Vaadin 24

### DIFF
--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/GridHelperElement.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/GridHelperElement.java
@@ -43,7 +43,8 @@ public class GridHelperElement extends MyGridElement {
 
   public List<CheckboxElement> getColumnToggleElements() {
     try {
-      return new ElementQuery<>(TestBenchElement.class, "vaadin-context-menu-overlay")
+      return new ElementQuery<>(TestBenchElement.class,
+          "vaadin-context-menu-overlay, vaadin-menu-bar-overlay")
           .context(getDriver())
           .waitForFirst(0)
           .$(CheckboxElement.class).all();


### PR DESCRIPTION
There is no `vaadin-context-menu-overlay` in Vaadin 24 (it's `vaadin-menu-bar-overlay`)