### PR TITLE
Version 1.1.0 heightByRows fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<description>Grid Helpers Add-on for Vaadin Flow</description>
 
 	<properties>
-		<vaadin.version>23.3.11</vaadin.version>
+		<vaadin.version>23.3.15</vaadin.version>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/HeightByRowsHelper.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/HeightByRowsHelper.java
@@ -1,5 +1,6 @@
 package com.flowingcode.vaadin.addons.gridhelpers;
 
+import com.vaadin.flow.component.grid.Grid;
 import java.io.Serializable;
 import java.util.Optional;
 import lombok.Getter;
@@ -29,9 +30,10 @@ class HeightByRowsHelper implements Serializable {
 
     heightByRows = rows;
 
-    if (heightMode == HeightMode.ROW) {
-      helper.getGrid().getElement().executeJs("this.fcGridHelper.setHeightByRows($0)", rows);
-      helper.getGrid().setThemeName(THEME, heightMode == HeightMode.ROW);
+    Grid<?> grid = helper.getGrid();
+    if (heightMode == HeightMode.ROW && grid.isAttached()) {
+      grid.getElement().executeJs("this.fcGridHelper.setHeightByRows($0)", rows);
+      grid.setThemeName(THEME, heightMode == HeightMode.ROW);
     }
   }
 

--- a/src/main/resources/META-INF/frontend/fcGridHelper/connector.js
+++ b/src/main/resources/META-INF/frontend/fcGridHelper/connector.js
@@ -54,8 +54,16 @@ import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 
 		grid.fcGridHelper = {
 			setHeightByRows : function(n) {
-				var height = grid.fcGridHelper.computeHeightByRows(n);
-				grid.style.setProperty('--height-by-rows',height+'px');
+				if (grid.fcGridHelper._heightByRowsObserver) {
+					grid.fcGridHelper._heightByRowsObserver.unobserve(grid);
+				}
+				
+				grid.fcGridHelper._heightByRowsObserver = new ResizeObserver(() => {
+					var height = grid.fcGridHelper.computeHeightByRows(n);
+					grid.style.setProperty('--height-by-rows',height+'px');
+				});
+				
+				grid.fcGridHelper._heightByRowsObserver.observe(grid);
 			},
 			
 			computeHeightByRows : function(n) {

--- a/src/main/resources/META-INF/frontend/fcGridHelper/connector.js
+++ b/src/main/resources/META-INF/frontend/fcGridHelper/connector.js
@@ -79,6 +79,7 @@ import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 				height += table.clientHeight - clientHeight;
 				table.style.overflowX = '';
 				
+				height += grid.offsetHeight-grid.clientHeight;
 				return height;
 			},
 

--- a/src/main/resources/META-INF/frontend/fcGridHelper/connector.js
+++ b/src/main/resources/META-INF/frontend/fcGridHelper/connector.js
@@ -61,12 +61,15 @@ import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
 			computeHeightByRows : function(n) {
 				var height = 0;
 				var rows = grid.shadowRoot.querySelectorAll("tbody tr");
-				for(var i=0;i<n && i<rows.length;i++) {
-					height += rows[i].offsetHeight;
-				}
 				
-				if (rows.length<n) {
-				  height *= n/rows.length;
+				if (rows.length>0) {
+					for(var i=0;i<n && i<rows.length;i++) {
+						height += rows[i].offsetHeight;
+					}
+				
+					if (rows.length<n) {
+						height *= n/rows.length;
+					}
 				}
 				
 				height += grid.shadowRoot.querySelector("thead").offsetHeight;

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/GridHelperElement.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/GridHelperElement.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
@@ -76,4 +77,27 @@ public class GridHelperElement extends MyGridElement {
         .isPresent();
   }
 
+  @Override
+  public int getFirstVisibleRowIndex() {
+    Long result = (Long) executeScript("return this._firstVisibleIndex");
+    return Optional.ofNullable(result).orElse(0L).intValue();
+  }
+
+  @Override
+  public int getLastVisibleRowIndex() {
+    Long result = (Long) executeScript("return this._lastVisibleIndex");
+    return Optional.ofNullable(result).orElse(-1L).intValue();
+  }
+
+  public Object getVisibleRowsCount() {
+    return getLastVisibleRowIndex() - getFirstVisibleRowIndex() + 1;
+  }
+
+  public int getOffsetHeight() {
+    return ((Long) executeScript("return this.offsetHeight")).intValue();
+  }
+
+  public String getHeightByRowsSize() {
+    return (String) executeScript("return this.style.getPropertyValue('--height-by-rows')");
+  }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeightByRowsIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeightByRowsIT.java
@@ -1,32 +1,80 @@
 package com.flowingcode.vaadin.addons.gridhelpers.it;
 
+import static com.flowingcode.vaadin.addons.gridhelpers.it.HeightByRowsITView.EMPTY;
+import static com.flowingcode.vaadin.addons.gridhelpers.it.HeightByRowsITView.FULLSIZE;
 import static org.junit.Assert.assertEquals;
 import com.flowingcode.vaadin.addons.gridhelpers.HeightMode;
 import com.flowingcode.vaadin.testbench.rpc.HasRpcSupport;
 import com.vaadin.flow.component.grid.testbench.GridElement;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.Test;
 
 public class HeightByRowsIT extends AbstractViewTest implements HasRpcSupport {
 
-  IntegrationViewCallables $server = createCallableProxy(IntegrationViewCallables.class);
+  private static int ROWS = 10;
+
+  HeightByRowsITViewCallables $server = createCallableProxy(HeightByRowsITViewCallables.class);
 
   GridHelperElement grid;
 
   public HeightByRowsIT() {
-    super("it");
+    super(HeightByRowsITView.ROUTE);
+  }
+
+  private void open(Object... args) {
+    if (grid != null) {
+      throw new IllegalStateException();
+    }
+    String params = Stream.of(args).map(Object::toString).collect(Collectors.joining(";"));
+    getDriver().get(getDriver().getCurrentUrl() + "/" + params);
+    grid = new GridHelperElement($(GridElement.class).waitForFirst());
+    $server.roundtrip();
   }
 
   @Override
   public void setup() throws Exception {
     super.setup();
-    grid = new GridHelperElement($(GridElement.class).waitForFirst());
   }
 
   @Test
-  public void test() {
-    $server.setHeightMode(HeightMode.ROW);
-    $server.setHeightByRows(10);
-    assertEquals(10, grid.getLastVisibleRowIndex());
+  public void testOpenWithItemsDefaultSize() {
+    open(ROWS);
+    assertEquals(ROWS, grid.getVisibleRowsCount());
+    assertEquals(ROWS, $server.getHeightByRows(), 0);
+    assertEquals(HeightMode.ROW, $server.getHeightMode());
+    assertEquals(453, grid.getOffsetHeight());
+    assertEquals("453px", grid.getHeightByRowsSize());
+  }
+
+  @Test
+  public void testOpenWithItemsFullSize() {
+    open(ROWS, FULLSIZE);
+    assertEquals(ROWS, grid.getVisibleRowsCount());
+    assertEquals(ROWS, $server.getHeightByRows(), 0);
+    assertEquals(HeightMode.ROW, $server.getHeightMode());
+    assertEquals(453, grid.getOffsetHeight());
+    assertEquals("453px", grid.getHeightByRowsSize());
+  }
+
+  @Test
+  public void testOpenEmptyDefaultSize() {
+    open(ROWS, EMPTY);
+    assertEquals(0, grid.getVisibleRowsCount());
+    assertEquals(ROWS, $server.getHeightByRows(), 0);
+    assertEquals(HeightMode.ROW, $server.getHeightMode());
+    assertEquals(94, grid.getOffsetHeight());
+    assertEquals("94px", grid.getHeightByRowsSize());
+  }
+
+  @Test
+  public void testOpenEmptyFullSize() {
+    open(ROWS, EMPTY, FULLSIZE);
+    assertEquals(0, grid.getVisibleRowsCount());
+    assertEquals(ROWS, $server.getHeightByRows(), 0);
+    assertEquals(HeightMode.ROW, $server.getHeightMode());
+    assertEquals(94, grid.getOffsetHeight());
+    assertEquals("94px", grid.getHeightByRowsSize());
   }
 
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeightByRowsITView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeightByRowsITView.java
@@ -1,0 +1,99 @@
+package com.flowingcode.vaadin.addons.gridhelpers.it;
+
+import com.flowingcode.vaadin.addons.gridhelpers.GridHelper;
+import com.flowingcode.vaadin.addons.gridhelpers.HeightMode;
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.OptionalParameter;
+import com.vaadin.flow.router.Route;
+import elemental.json.JsonObject;
+import elemental.json.JsonValue;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.experimental.ExtensionMethod;
+
+@ExtensionMethod(GridHelper.class)
+@Route(HeightByRowsITView.ROUTE)
+public class HeightByRowsITView extends VerticalLayout
+    implements HeightByRowsITViewCallables, HasUrlParameter<String> {
+
+  public static final String ROUTE = "it/height-by-rows";
+
+  public static final String EMPTY = "empty";
+
+  public static final String FULLSIZE = "fullsize";
+
+  public static final String NO_COLUMNS = "nocolumns";
+
+  private Grid<Integer> grid;
+
+  @Override
+  public void setParameter(BeforeEvent event, @OptionalParameter String parameter) {
+    removeAll();
+
+    if (parameter == null) {
+      return;
+    }
+
+    List<String> params = Arrays.asList(parameter.split(";"));
+
+    if (params.contains(FULLSIZE)) {
+      setSizeFull();
+    }
+
+    grid = new Grid<>();
+
+    if (!params.contains(NO_COLUMNS)) {
+      grid.addColumn(x -> x).setHeader("Header").setFooter("Footer");
+    }
+
+    if (!params.contains(EMPTY)) {
+      grid.setItems(IntStream.range(1, 100).mapToObj(Integer::valueOf).toArray(Integer[]::new));
+    }
+
+    params.stream()
+      .filter(s -> s.matches("\\d+"))
+      .findFirst().map(Integer::valueOf)
+      .ifPresent(rows -> {
+        grid.setHeightMode(HeightMode.ROW);
+          grid.setHeightByRows(rows);
+        });
+
+    add(grid);
+  }
+
+  @Override
+  @ClientCallable
+  public JsonValue $call(JsonObject invocation) {
+    return HeightByRowsITViewCallables.super.$call(invocation);
+  }
+
+  @Override
+  public HeightMode getHeightMode() {
+    return grid.getHeightMode();
+  }
+
+  @Override
+  public void setHeightMode(HeightMode row) {
+    grid.setHeightMode(row);
+  }
+
+  @Override
+  public double getHeightByRows() {
+    return grid.getHeightByRows();
+  }
+
+  @Override
+  public void setHeightByRows(int rows) {
+    grid.setHeightByRows(rows);
+  }
+
+  @Override
+  public void roundtrip() {
+    // do nothing
+  }
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeightByRowsITViewCallables.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeightByRowsITViewCallables.java
@@ -1,0 +1,18 @@
+package com.flowingcode.vaadin.addons.gridhelpers.it;
+
+import com.flowingcode.vaadin.addons.gridhelpers.HeightMode;
+import com.flowingcode.vaadin.testbench.rpc.RmiCallable;
+
+public interface HeightByRowsITViewCallables extends RmiCallable {
+
+  double getHeightByRows();
+
+  void setHeightByRows(int heightByRows);
+
+  HeightMode getHeightMode();
+
+  void setHeightMode(HeightMode row);
+
+  void roundtrip();
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/IntegrationView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/IntegrationView.java
@@ -1,7 +1,6 @@
 package com.flowingcode.vaadin.addons.gridhelpers.it;
 
 import com.flowingcode.vaadin.addons.gridhelpers.GridHelper;
-import com.flowingcode.vaadin.addons.gridhelpers.HeightMode;
 import com.flowingcode.vaadin.addons.gridhelpers.Person;
 import com.flowingcode.vaadin.addons.gridhelpers.TestData;
 import com.flowingcode.vaadin.testbench.rpc.JsonArrayList;
@@ -155,18 +154,6 @@ public class IntegrationView extends Div implements IntegrationViewCallables {
   public void removeAllItems() {
     ((ListDataProvider<?>) grid.getDataProvider()).getItems().clear();
     grid.getDataProvider().refreshAll();
-  }
-
-  @Override
-  @ClientCallable
-  public void setHeightMode(HeightMode row) {
-    grid.setHeightMode(row);
-  }
-
-  @Override
-  @ClientCallable
-  public void setHeightByRows(int rows) {
-    grid.setHeightByRows(rows);
   }
 
   @Override

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/IntegrationViewCallables.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/IntegrationViewCallables.java
@@ -1,6 +1,5 @@
 package com.flowingcode.vaadin.addons.gridhelpers.it;
 
-import com.flowingcode.vaadin.addons.gridhelpers.HeightMode;
 import com.flowingcode.vaadin.testbench.rpc.JsonArrayList;
 import com.vaadin.flow.component.grid.Grid.SelectionMode;
 
@@ -35,10 +34,6 @@ public interface IntegrationViewCallables {
     void addToolbarFooter(String footer);
 
     void removeAllItems();
-
-    void setHeightMode(HeightMode row);
-
-    void setHeightByRows(int rows);
 
     void setHeaderVisible(boolean visible);
 

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/ResponsiveGridIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/ResponsiveGridIT.java
@@ -46,6 +46,11 @@ public class ResponsiveGridIT extends AbstractViewTest implements HasRpcSupport 
   private void setWidth(int w) {
     executeScript("arguments[0].parentElement.style.width=" + w + "+'px';", grid);
     $server.roundtrip();
+    try {
+      Thread.sleep(100);
+    } catch (InterruptedException e) {
+      return;
+    }
   }
 
   @Test
@@ -63,9 +68,10 @@ public class ResponsiveGridIT extends AbstractViewTest implements HasRpcSupport 
   }
 
   @Test
-  public void testHideAll() {
+  public void testHideAll() throws InterruptedException {
     $server.responsiveStep(0).hideAll();
     $server.roundtrip();
+    Thread.sleep(100);
     assertTrue(grid.getVisibleColumns().isEmpty());
   }
 
@@ -92,20 +98,23 @@ public class ResponsiveGridIT extends AbstractViewTest implements HasRpcSupport 
   }
 
   @Test
-  public void testRemove() {
+  public void testRemove() throws InterruptedException {
     $server.responsiveStep(300);
     $server.responsiveStep(400);
     $server.roundtrip();
+    Thread.sleep(100);
     assertEquals(400, $server.getCurrentStep());
 
     $server.responsiveStep(400).remove();
     $server.roundtrip();
+    Thread.sleep(100);
     assertEquals(300, $server.getCurrentStep());
   }
 
   @Test
   public void testAddListenerFireImmediately() {
     IListenerRegistration listener = $server.responsiveStep(200).addListener();
+    $server.roundtrip();
     assertEquals(1, listener.getCount());
     assertEquals(200, listener.getLastMinWidth());
   }
@@ -133,7 +142,7 @@ public class ResponsiveGridIT extends AbstractViewTest implements HasRpcSupport 
   }
 
   @Test
-  public void testListenerCumulative() {
+  public void testListenerCumulative() throws InterruptedException {
     setWidth(200);
     IListenerRegistration listener = $server.responsiveStep(300).addListener();
     $server.responsiveStep(400);


### PR DESCRIPTION
Several fixes related to heightByRows. Close #80 

- There was a call to setHeightByRows when the grid was not attached. This call was redundant since attaching the Grid would cause the height to be recomputed.

- Avoid division by zero if the grid is empty.

- Add Grid's own borders to the computed height (by default grid has `box-sizing: border-box`, and borders will be substracted from the set `height`)

- Recompute heightByRows when the grid height is updated:
	- When the grid is initially attached, it has no columns and it's too early to measure rows in the browser.
	- When the size of the parent component is undefined, the grid may be rendered with no data. The first call to `computeHeightByRows` will just return header+footer, causing data to be retrieved later. 
	- When the computed height is set, fire another call to `computeHeightByRows`, so that a new height is computed, avoiding sub-pixel rounding errors.

Also, add some thread sleep in order to reduce flakiness in ResponsiveGridIT.
