### PR TITLE
feat: add checkbox column helper

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/CheckboxColumn.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/CheckboxColumn.java
@@ -1,0 +1,272 @@
+/*-
+ * #%L
+ * Grid Helpers Add-on
+ * %%
+ * Copyright (C) 2022 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.flowingcode.vaadin.addons.gridhelpers;
+
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.component.grid.ColumnTextAlign;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.data.provider.BackEndDataProvider;
+import com.vaadin.flow.data.provider.InMemoryDataProvider;
+import com.vaadin.flow.function.SerializableBiConsumer;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.ValueProvider;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.IntSupplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+/**
+ * A grid column where boolean value is rendered as a {@link Checkbox}.
+ * <p/>
+ * By default select all checkbox is visible when grid uses an {@link InMemoryDataProvider}, or it's
+ * hidden when a {@link BackEndDataProvider} is used.
+ * <p/>
+ * When select all checkbox is visible, {@link CheckboxColumn} must be explicitly refreshed if grid
+ * dataprovider changes after column creation using {@code CheckboxColumn.refresh()} method.
+ * 
+ * @param <T>
+ */
+@SuppressWarnings("serial")
+@RequiredArgsConstructor
+@Accessors(fluent = true)
+public final class CheckboxColumn<T> implements Serializable {
+
+  @RequiredArgsConstructor
+  @Accessors(fluent = true)
+  public static class CheckboxColumnConfiguration<T> implements Serializable {
+    private final ValueProvider<T, Boolean> getter;
+    @Setter
+    private String header;
+    @Setter
+    private boolean readOnly = false;
+    @Setter
+    private Boolean selectAllCheckboxVisible;
+    @Setter
+    private CheckboxPosition checkboxPosition = CheckboxPosition.TOP;
+  }
+
+  @AllArgsConstructor
+  public enum CheckboxPosition {
+    TOP("fcgh-checkbox-top"), RIGHT("fcgh-checkbox-right"), BOTTOM("fcgh-checkbox-bottom"), LEFT("fcgh-checkbox-left");
+
+    private String theme;
+  }
+
+  private final Grid<T> grid;
+  @Getter
+  private final Column<T> column;
+  private final Map<T, Boolean> itemsState = new HashMap<>();
+  private final transient IntSupplier totalItemsCount;
+  private final transient IntSupplier selectedItemsCount;
+  private final Checkbox selectAllCheckbox;
+  private final CheckboxColumnConfiguration<T> config;
+  @Setter
+  private SerializableBiConsumer<T, Boolean> checkboxClickListener;
+  @Setter
+  private SerializableConsumer<Integer> checkedCountListener;
+
+  CheckboxColumn(Grid<T> grid, CheckboxColumnConfiguration<T> config) {
+    this.grid = grid;
+    this.config = config;
+
+    if (config.selectAllCheckboxVisible == null) {
+      config.selectAllCheckboxVisible = grid.getDataProvider().isInMemory();
+    }
+
+    if (!config.readOnly && Boolean.TRUE.equals(config.selectAllCheckboxVisible)) {
+      this.totalItemsCount = () -> getItemsCount(grid);
+      this.selectedItemsCount =
+          () -> (int) itemsState.values().stream().filter(Boolean.TRUE::equals).count();
+    } else {
+      this.totalItemsCount = () -> 0;
+      this.selectedItemsCount = () -> 0;
+    }
+
+    this.selectAllCheckbox = buildSelectAllCheckbox(config, grid).orElse(null);
+
+    this.column = grid
+        .addComponentColumn(item -> buildCheckbox(config, item))
+        .setTextAlign(ColumnTextAlign.CENTER);
+
+    if (config.readOnly) {
+      this.column.setHeader(config.header);
+    } else {
+      initializeNotReadOnly(grid, config);
+    }
+  }
+
+  private void initializeNotReadOnly(Grid<T> grid, CheckboxColumnConfiguration<T> config) {
+    if (selectAllCheckbox != null) {
+      this.column.setHeader(selectAllCheckbox);
+    } else {
+      this.column.setHeader(config.header);
+    }
+
+    this.column.addAttachListener(e -> {
+      if (e.isInitialAttach()) {
+        this.initItemsState(grid, config.getter);
+        initializeSelectAllCheckbox(grid, selectAllCheckbox, config.getter);
+      }
+    });
+  }
+
+  /**
+   * Refreshes select all checkbox status to reflect the underlying data.
+   * <p/>
+   * This method must be invoked when grid's dataprovider changes.
+   */
+  public void refresh() {
+    this.initItemsState(grid, config.getter);
+    initializeSelectAllCheckbox(grid, selectAllCheckbox, config.getter);
+  }
+
+  private void initializeSelectAllCheckbox(Grid<T> grid, Checkbox selectAllCheckbox,
+      ValueProvider<T, Boolean> getter) {
+    if (selectAllCheckbox != null) {
+      int initialSelectedItemsCountValue = getInitialSelectItemsCount(grid, getter);
+      int totalItemsCountValue = this.totalItemsCount.getAsInt();
+      selectAllCheckbox.setValue(initialSelectedItemsCountValue > 0);
+      selectAllCheckbox.setIndeterminate(initialSelectedItemsCountValue < totalItemsCountValue);
+    }
+  }
+
+  /**
+   * Returns the items whose corresponding checkbox is checked.
+   * 
+   * @return selected items.
+   */
+  public Set<T> getSelectedItems() {
+    return itemsState.entrySet().stream().filter(Entry::getValue).map(Entry::getKey)
+        .collect(Collectors.toSet());
+  }
+
+  private int getItemsCount(Grid<T> grid) {
+    return grid.getDataProvider().isInMemory() ? grid.getListDataView().getItemCount()
+        : (int) grid.getLazyDataView().getItems().count();
+  }
+
+  private int getInitialSelectItemsCount(Grid<T> grid, ValueProvider<T, Boolean> filter) {
+    return grid.getDataProvider().isInMemory()
+        ? (int) grid.getListDataView().getItems().filter(filter::apply).count()
+        : (int) grid.getLazyDataView().getItems().filter(filter::apply).count();
+  }
+
+  private void initItemsState(Grid<T> grid, ValueProvider<T, Boolean> getter) {
+    itemsState.clear();
+
+    if (grid.getDataProvider().isInMemory()) {
+      grid.getListDataView().getItems()
+          .forEach(item -> itemsState.computeIfAbsent(item, getter));
+    } else {
+      grid.getLazyDataView().getItems()
+          .forEach(item -> itemsState.computeIfAbsent(item, getter));
+    }
+  }
+
+  private Optional<Checkbox> buildSelectAllCheckbox(CheckboxColumnConfiguration<T> config,
+      Grid<T> grid) {
+    if (config.readOnly || Boolean.TRUE.equals(!config.selectAllCheckboxVisible)) {
+      return Optional.empty();
+    }
+
+    Checkbox checkbox = new Checkbox(config.header);
+    checkbox.setIndeterminate(someItemsSelected());
+    checkbox.addValueChangeListener(e -> {
+      if (!e.isFromClient()) {
+        return;
+      }
+      if (someItemsSelected() && Boolean.TRUE.equals(!e.getValue())) {
+        checkbox.setValue(true);
+      }
+      Stream<T> items = grid.getDataProvider().isInMemory() ? grid.getListDataView().getItems()
+          : grid.getLazyDataView().getItems();
+      itemsState.clear();
+      items.forEach(item -> itemsState.put(item, checkbox.getValue()));
+      grid.getDataProvider().refreshAll();
+      checkbox.setIndeterminate(someItemsSelected());
+
+      notifyCheckedCountChanged(checkedCountListener);
+    });
+
+    checkbox.getElement().getThemeList().add("fcgh-small");
+
+    if (config.header != null && config.checkboxPosition.theme != null) {
+      checkbox.getElement().getThemeList().add(config.checkboxPosition.theme);
+    }
+
+    return Optional.of(checkbox);
+  }
+
+  private void notifyCheckboxClicked(SerializableBiConsumer<T, Boolean> listener, T item,
+      boolean value) {
+    Optional.ofNullable(listener).ifPresent(l -> l.accept(item, value));
+  }
+
+  private void notifyCheckedCountChanged(SerializableConsumer<Integer> listener) {
+    Optional.ofNullable(listener).ifPresent(l -> l.accept(getSelectedItems().size()));
+  }
+
+  private boolean someItemsSelected() {
+    return selectedItemsCount.getAsInt() > 0
+        && selectedItemsCount.getAsInt() < totalItemsCount.getAsInt();
+  }
+
+  private boolean allItemsSelected() {
+    return totalItemsCount.getAsInt() == selectedItemsCount.getAsInt();
+  }
+
+  private Checkbox buildCheckbox(CheckboxColumnConfiguration<T> config, T item) {
+    Checkbox checkbox = new Checkbox(itemsState.computeIfAbsent(item, config.getter::apply));
+    checkbox.setReadOnly(config.readOnly);
+
+    if (!config.readOnly) {
+      checkbox.addValueChangeListener(e -> {
+        itemsState.put(item, e.getValue());
+        if (selectAllCheckbox != null) {
+          if (allItemsSelected()) {
+            selectAllCheckbox.setValue(true);
+            selectAllCheckbox.setIndeterminate(false);
+          } else if (someItemsSelected()) {
+            selectAllCheckbox.setValue(true);
+            selectAllCheckbox.setIndeterminate(true);
+          } else {
+            selectAllCheckbox.setValue(false);
+            selectAllCheckbox.setIndeterminate(false);
+          }
+        }
+        notifyCheckboxClicked(checkboxClickListener, item, e.getValue());
+        notifyCheckedCountChanged(checkedCountListener);
+      });
+    }
+    return checkbox;
+  }
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/CheckboxColumnGridHelper.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/CheckboxColumnGridHelper.java
@@ -1,0 +1,53 @@
+/*-
+ * #%L
+ * Grid Helpers Add-on
+ * %%
+ * Copyright (C) 2022 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.flowingcode.vaadin.addons.gridhelpers;
+
+import com.flowingcode.vaadin.addons.gridhelpers.CheckboxColumn.CheckboxColumnConfiguration;
+import com.vaadin.flow.component.checkbox.Checkbox;
+import com.vaadin.flow.data.provider.BackEndDataProvider;
+import java.io.Serializable;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Helper class to create a grid column where boolean value is rendered as a {@link Checkbox}.
+ * <p/>
+ * Note that using this helper with a {@link BackEndDataProvider} could lead to performance
+ * penalties as the total amount of items must be fetched from backend.
+ * 
+ * @param <T>
+ */
+@SuppressWarnings("serial")
+@RequiredArgsConstructor
+final class CheckboxColumnGridHelper<T> implements Serializable {
+
+  private final GridHelper<T> helper;
+
+  /**
+   * Creates a {@link CheckboxColumn} using a given configuration.
+   * 
+   * @param config configuration to apply.
+   * @return the created {@link CheckboxColumn}
+   */
+  public CheckboxColumn<T> addCheckboxColumn(
+      CheckboxColumnConfiguration<T> config) {
+    return new CheckboxColumn<>(helper.getGrid(), config);
+  }
+}

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelper.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelper.java
@@ -20,6 +20,7 @@
 
 package com.flowingcode.vaadin.addons.gridhelpers;
 
+import com.flowingcode.vaadin.addons.gridhelpers.CheckboxColumn.CheckboxColumnConfiguration;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -63,6 +64,9 @@ import org.slf4j.LoggerFactory;
 @CssImport(
     value = "./fcGridHelper/vaadin-menu-bar-list-box.css",
     themeFor = "vaadin-menu-bar-list-box")
+@CssImport(
+    value = "./fcGridHelper/vaadin-checkbox.css",
+    themeFor = "vaadin-checkbox")
 public final class GridHelper<T> implements Serializable {
 
   private static final Logger logger = LoggerFactory.getLogger(GridHelper.class);
@@ -521,7 +525,15 @@ public final class GridHelper<T> implements Serializable {
   public static <T> Collection<GridResponsiveStep<T>> getResponsiveSteps(Grid<T> grid) {
     return getHelper(grid).responsiveGridHelper.getAll();
   }
+  
+  private final CheckboxColumnGridHelper<T> checkboxColumnGridHelper =
+      new CheckboxColumnGridHelper<>(this);
 
+  public static <T> CheckboxColumn<T> addCheckboxColumn(Grid<T> grid,
+      CheckboxColumnConfiguration<T> config) {
+    return getHelper(grid).checkboxColumnGridHelper.addCheckboxColumn(config);
+  }
+  
   private final LazySelectAllGridHelper<T> lazySelectAllGridHelper =
       new LazySelectAllGridHelper<>(this);
 

--- a/src/main/resources/META-INF/frontend/fcGridHelper/vaadin-checkbox.css
+++ b/src/main/resources/META-INF/frontend/fcGridHelper/vaadin-checkbox.css
@@ -1,0 +1,59 @@
+:host([theme~='fcgh-checkbox-top']) .vaadin-checkbox-container [part="checkbox"] {
+  grid-column: 1;
+  grid-row: 1;
+  justify-self: center;
+}
+
+:host([theme~='fcgh-checkbox-top']) ::slotted(input) {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+:host([theme~='fcgh-checkbox-top']) .vaadin-checkbox-container ::slotted(label) {
+  grid-column: 1;
+  grid-row: 2;
+  padding-inline: 0;
+}
+
+:host([theme~='fcgh-checkbox-bottom']) .vaadin-checkbox-container [part="checkbox"] {
+  grid-column: 1;
+  grid-row: 2;
+  justify-self: center;
+}
+
+:host([theme~='fcgh-checkbox-bottom']) ::slotted(input) {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+:host([theme~='fcgh-checkbox-bottom']) .vaadin-checkbox-container ::slotted(label) {
+  grid-column: 1;
+  grid-row: 1;
+  padding-inline: 0;
+}
+
+:host([theme~='fcgh-checkbox-left']) .vaadin-checkbox-container [part="checkbox"], 
+:host([theme~='fcgh-checkbox-left']) ::slotted(input) {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+:host([theme~='fcgh-checkbox-left']) .vaadin-checkbox-container ::slotted(label) {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+:host([theme~='fcgh-checkbox-right']) .vaadin-checkbox-container [part="checkbox"], 
+:host([theme~='fcgh-checkbox-right']) ::slotted(input) {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+:host([theme~='fcgh-checkbox-right']) .vaadin-checkbox-container ::slotted(label) {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+:host([theme~='fcgh-small']) ::slotted(label) {
+ font-size: var(--lumo-font-size-s);
+}  

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/CheckboxColumnDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/CheckboxColumnDemo.java
@@ -1,0 +1,91 @@
+/*-
+ * #%L
+ * Grid Helpers Add-on
+ * %%
+ * Copyright (C) 2022 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.flowingcode.vaadin.addons.gridhelpers;
+
+import com.flowingcode.vaadin.addons.demo.DemoSource;
+import com.flowingcode.vaadin.addons.gridhelpers.CheckboxColumn.CheckboxColumnConfiguration;
+import com.flowingcode.vaadin.addons.gridhelpers.CheckboxColumn.CheckboxPosition;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+@PageTitle("Checkbox Column")
+@DemoSource
+@Route(value = "grid-helpers/checkbox-column", layout = GridHelpersDemoView.class)
+public class CheckboxColumnDemo extends VerticalLayout {
+
+  public CheckboxColumnDemo() {
+    setSizeFull();
+
+    Span activeCount = new Span();
+    Span vipCount = new Span();
+
+    Grid<Person> grid = new Grid<>();
+    LazyTestData data = new LazyTestData();
+    grid.setItems(DataProvider.fromCallbacks(
+        query -> data.filter(query.getOffset(), query.getPageSize()), query -> data.count()));
+
+    grid.addColumn(Person::getFirstName).setHeader("First name");
+    grid.addColumn(Person::getLastName).setHeader("Last name");
+    CheckboxColumn<Person> activeColumn = GridHelper
+        .addCheckboxColumn(grid,
+            new CheckboxColumnConfiguration<>(Person::isActive)
+                .header("Active")
+                .checkboxPosition(CheckboxPosition.LEFT)
+                .selectAllCheckboxVisible(true))
+        .checkboxClickListener((item,
+            checked) -> Notification.show(item.getFirstName() + " " + item.getLastName()
+                + " " + (checked ? "checked" : "unchecked")))
+        .checkedCountListener(count -> activeCount.setText("Active count: " + count));
+    GridHelper
+        .addCheckboxColumn(grid,
+            new CheckboxColumnConfiguration<>(Person::isVip)
+                .header("VIP"))
+        .checkboxClickListener((item, checked) -> Notification
+            .show(item.getFirstName() + " " + item.getLastName()
+                + " " + (checked ? "checked" : "unchecked")))
+        .checkedCountListener(count -> vipCount.setText("VIP count: " + count));
+    GridHelper
+        .addCheckboxColumn(grid,
+            new CheckboxColumnConfiguration<>(Person::isHidden)
+                .header("Hidden")
+                .readOnly(true));
+
+    grid.setSizeFull();
+
+    Button toggleVipColumn = new Button("Refresh grid data");
+    toggleVipColumn.addClickListener(e -> {
+      LazyTestData newData = new LazyTestData();
+      grid.setItems(DataProvider.fromCallbacks(
+          query -> newData.filter(query.getOffset(), query.getPageSize()),
+          query -> newData.count()));
+      activeColumn.refresh();
+    });
+
+    add(grid, toggleVipColumn, new HorizontalLayout(activeCount, vipCount));
+  }
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelpersDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelpersDemoView.java
@@ -49,5 +49,6 @@ public class GridHelpersDemoView extends TabbedDemo {
     addDemo(AddToolbarFooterDemo.class);
     addDemo(GetHeaderFooterDemo.class);
     addDemo(LazyMultiSelectionDemo.class);
+    addDemo(CheckboxColumnDemo.class);
   }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/LazyTestData.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/LazyTestData.java
@@ -25,13 +25,15 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class LazyTestData {
+class LazyTestData {
 
   private static final Faker faker = new Faker();
 
   private static synchronized Person newPerson() {
     return Person.builder()
         .active(faker.random().nextBoolean())
+        .vip(faker.random().nextBoolean())
+        .hidden(faker.random().nextBoolean())
         .firstName(faker.name().firstName())
         .lastName(faker.name().lastName())
         .country(generateCountry())

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/Person.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/Person.java
@@ -25,7 +25,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
 
 @Getter
 @AllArgsConstructor
@@ -33,7 +35,15 @@ import lombok.experimental.FieldDefaults;
 @EqualsAndHashCode
 @Builder
 public class Person {
+  @Setter
+  @NonFinal
   boolean active;
+  @Setter
+  @NonFinal
+  boolean vip;
+  @Setter
+  @NonFinal
+  boolean hidden;
   String firstName;
   String lastName;
   String country;
@@ -42,4 +52,9 @@ public class Person {
   String emailAddress;
   String phoneNumber;
   String title;
+  
+  @Override
+  public String toString() {
+    return firstName+" "+lastName+" - active: "+active;
+  }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/TestData.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/TestData.java
@@ -32,6 +32,8 @@ public class TestData {
   private static synchronized Person newPerson() {
     return Person.builder()
         .active(faker.random().nextBoolean())
+        .vip(faker.random().nextBoolean())
+        .hidden(faker.random().nextBoolean())
         .firstName(faker.name().firstName())
         .lastName(faker.name().lastName())
         .country(generateCountry())


### PR DESCRIPTION
Given that Vaadin's Grid doesn't provide a way to know when its dataprovider changes, if Select All checkbox is visible, and in order to keep it in sync with grid data, user must explicitly refresh the CheckboxColumn invoking refresh() method.

Close #69