### PR TITLE
fix: steps array values should be ascending sorted

### DIFF
--- a/src/main/resources/META-INF/frontend/fcGridHelper/connector.js
+++ b/src/main/resources/META-INF/frontend/fcGridHelper/connector.js
@@ -108,7 +108,7 @@ import { Grid } from '@vaadin/grid/src/vaadin-grid.js';
   			
 			_setResponsiveSteps : function(widths) {
 				const observer = grid.fcGridHelper._resizeObserver;
-				observer.widths=widths.sort();
+				observer.widths=widths.sort((a, b) => a - b);
 				observer.unobserve(grid);
 				
 				if (widths.length>0) {


### PR DESCRIPTION
Array.prototype.sort() default sort order is ascending, built upon converting the elements into strings, then comparing their sequences of UTF-16 code units values.

Close #93