### PR TITLE
chore(demo): reorder HeightByRowsDemo

### DIFF
--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelpersDemoView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelpersDemoView.java
@@ -38,6 +38,7 @@ public class GridHelpersDemoView extends TabbedDemo {
     setSizeFull();
     addDemo(AllFeaturesDemo.class);
     addDemo(ColumnToggleMenuDemo.class);
+    addDemo(HeightByRowsDemo.class);
     addDemo(HideSelectionColumnDemo.class);
     addDemo(FreezeSelectionColumnDemo.class);
     addDemo(EnableArrowSelectionDemo.class);
@@ -51,7 +52,6 @@ public class GridHelpersDemoView extends TabbedDemo {
     addDemo(LazyMultiSelectionDemo.class);
     addDemo(CheckboxColumnDemo.class);
     addDemo(EmptyGridLabelDemo.class);
-    addDemo(HeightByRowsDemo.class);
     addDemo(GridRadioSelectionColumnDemo.class);
   }
 }


### PR DESCRIPTION
Move the `HeightByRowsDemo` to the left so that its tab is always visible.

![image](https://github.com/user-attachments/assets/5a8165a7-1df2-48b0-a46b-d73f6eabebc1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated demo view configuration to remove duplicate demo entry
	- Ensured `HeightByRowsDemo` is correctly included in the demo list

<!-- end of auto-generated comment: release notes by coderabbit.ai -->