### PR TITLE
fix: avoid IndexOutOfBoundsException in enhanced selection

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/EnhancedSelectionGridHelper.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/EnhancedSelectionGridHelper.java
@@ -2,7 +2,7 @@
  * #%L
  * Grid Helpers Add-on
  * %%
- * Copyright (C) 2022 - 2024 Flowing Code
+ * Copyright (C) 2022 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ class EnhancedSelectionGridHelper<T> implements Serializable {
       int newFocusedItemIndex =
           (int) ev.getEventData().getNumber(KEY_UP_ELEMENT_FOCUSED_ITEM_INDEX);
       if (newFocusedItemIndex >= 0) {
-        newFocusedItemMaybe = Optional.ofNullable(dataView.getItem(newFocusedItemIndex));
+        newFocusedItemMaybe = dataView.getItems().skip(newFocusedItemIndex).findFirst();
       }
 
       if (newFocusedItemMaybe.isPresent()) {


### PR DESCRIPTION
Close #125. 

`dataView.getItem` intentionally throws if the index is out of bounds, and `newFocusedItemIndex` happens to be 0 in the scenario proposed in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the grid’s selection handling for smoother and more reliable navigation through item lists. This update improves the accuracy of item focus, ensuring that interactions remain consistent even in edge-case scenarios during data exploration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->