### PR TITLE
Add explicit usage of RadioButtonGroup

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridRadioSelectionColumn.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridRadioSelectionColumn.java
@@ -26,6 +26,8 @@ import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.dependency.Uses;
+import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 
 /**
  * Server side implementation for the flow specific grid radio selection column.
@@ -34,6 +36,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.3.2")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("./fcGridHelper/grid-flow-radio-selection-column.js")
+@Uses(RadioButtonGroup.class)
 public class GridRadioSelectionColumn extends Component implements HasStyle {
 
   /**


### PR DESCRIPTION
Adding @Uses(RadioButtonGroup.class) to GridRadioSelectionColumn class ensures that vaadin-radio-button element dependencies are also loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated component dependencies to improve resource management for radio button selection in grid columns. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->