### PR TITLE
fix: ensure that Grid columns are configured before setting a footer toolbar

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/FooterToolbarGridHelper.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/FooterToolbarGridHelper.java
@@ -2,7 +2,7 @@
  * #%L
  * Grid Helpers Add-on
  * %%
- * Copyright (C) 2022 - 2024 Flowing Code
+ * Copyright (C) 2022 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,9 @@ class FooterToolbarGridHelper implements Serializable {
 
   public void setFooterToolbar(Component toolBar) {
     Grid<?> grid = helper.getGrid();
+    if (grid.getColumns().isEmpty()) {
+      throw new IllegalStateException("Cannot set footer toolbar: Grid columns have not been configured.");
+    }
     if (grid.getFooterRows().isEmpty()) {
       // create a fake footer and hide it (workaround:
       // https://github.com/vaadin/flow-components/issues/1558#issuecomment-987783794)

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelper.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelper.java
@@ -2,7 +2,7 @@
  * #%L
  * Grid Helpers Add-on
  * %%
- * Copyright (C) 2022 - 2024 Flowing Code
+ * Copyright (C) 2022 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -348,6 +348,16 @@ public final class GridHelper<T> implements Serializable {
 
   private final FooterToolbarGridHelper footerToolbar = new FooterToolbarGridHelper(this);
 
+  /**
+   * Adds a toolbar component to the footer of the grid.
+   * <p>
+   * Note: The grid must have its columns configured before calling this method.
+   * Otherwise, an {@link IllegalStateException} will be thrown.
+   *
+   * @param grid the grid to add the toolbar to
+   * @param toolBar the toolbar component to add
+   * @throws IllegalStateException if the grid columns have not been configured
+   */
   public static void addToolbarFooter(Grid<?> grid, Component toolBar) {
     getHelper(grid).footerToolbar.setFooterToolbar(toolBar);
   }

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/test/FooterToolbarTest.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/test/FooterToolbarTest.java
@@ -2,7 +2,7 @@
  * #%L
  * Grid Helpers Add-on
  * %%
- * Copyright (C) 2022 - 2024 Flowing Code
+ * Copyright (C) 2022 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,28 +22,24 @@ package com.flowingcode.vaadin.addons.gridhelpers.test;
 import com.flowingcode.vaadin.addons.gridhelpers.GridHelper;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.Test.None;
 
 public class FooterToolbarTest {
-  
-  private Grid<Bean> grid;
 
-  private HorizontalLayout toolbarFooter;
-  
-  private class Bean {}
-  
-  @Before
-  public void before() {
-    grid = new Grid<>(Bean.class, false);
+  private static class Bean {}
+
+  @Test
+  public void addToolbarFooter() {
+    Grid<Bean> grid = new Grid<>(Bean.class, false);
     grid.addColumn(x -> x).setHeader("Header");
-    toolbarFooter = new HorizontalLayout();    
-  }
-  
-  @Test(expected = None.class)
-  public void addToolbarFooter_toolbarFooterIsShown() {
+    var toolbarFooter = new HorizontalLayout();
     GridHelper.addToolbarFooter(grid, toolbarFooter);
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void testSetFooterToolbarBeforeColumnsConfiguredThrowsException() {
+    Grid<Bean> grid = new Grid<>(Bean.class, false);
+    var toolbarFooter = new HorizontalLayout();
+    GridHelper.addToolbarFooter(grid, toolbarFooter);
+  }
 }


### PR DESCRIPTION
Add a explicit check to ensure the grid has columns before the toolbar is initialized.

Close #129 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling when adding a footer toolbar to a grid without configured columns, now displaying a clear exception if attempted.

- **Documentation**
  - Enhanced method documentation to clarify usage requirements and exceptions for adding a toolbar footer to a grid.

- **Tests**
  - Added and updated tests to verify correct exception handling and footer toolbar functionality in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->