### PR TITLE
fix: fix column index calculation when cells are joined

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/HeaderFooterStylesHelper.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/HeaderFooterStylesHelper.java
@@ -2,7 +2,7 @@
  * #%L
  * Grid Helpers Add-on
  * %%
- * Copyright (C) 2022 - 2024 Flowing Code
+ * Copyright (C) 2022 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,11 +133,17 @@ class HeaderFooterStylesHelper implements Serializable {
     private int getColumnIndex(int rowIndex) {
       ROW row = getRowSelector().getRow();
       int j = -1;
+
+      CELL last = null;
       for (Column<?> c : helper.getGrid().getColumns()) {
         if (c.isVisible()) {
-          ++j;
-          if (getCell(row, c) == getCell()) {
-            break;
+          CELL curr = getCell(row, c);
+          if (curr != last) {
+            ++j;
+            last = curr;
+            if (curr == getCell()) {
+              break;
+            }
           }
         }
       }

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/GridHelperElement.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/GridHelperElement.java
@@ -2,7 +2,7 @@
  * #%L
  * Grid Helpers Add-on
  * %%
- * Copyright (C) 2022 - 2024 Flowing Code
+ * Copyright (C) 2022 - 2025 Flowing Code
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,5 +126,16 @@ public class GridHelperElement extends MyGridElement {
 
   public String getHeightByRowsSize() {
     return (String) executeScript("return this.style.getPropertyValue('--height-by-rows')");
+  }
+
+  public WebElement getHeaderRow(int rowIndex) {
+    WebElement thead = $("*").id("header");
+    List<WebElement> headerRows = thead.findElements(By.tagName("tr"));
+    return headerRows.get(rowIndex);
+  }
+
+  public WebElement getHeaderCell(int rowIndex, int columnIndex) {
+    List<WebElement> headerCells = getHeaderRow(rowIndex).findElements(By.tagName("th"));
+    return headerCells.get(columnIndex);
   }
 }

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeaderFooterStylesCallables.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeaderFooterStylesCallables.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * Grid Helpers Add-on
+ * %%
+ * Copyright (C) 2022 - 2025 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.gridhelpers.it;
+
+import com.flowingcode.vaadin.addons.gridhelpers.GridStylesHelper;
+import com.flowingcode.vaadin.testbench.rpc.RmiCallable;
+import com.flowingcode.vaadin.testbench.rpc.RmiRemote;
+
+public interface HeaderFooterStylesCallables extends RmiCallable {
+
+  public interface HeaderRowWrapper extends GridStylesHelper, RmiRemote {
+    HeaderCellWrapper getCell(int columnIndex);
+    HeaderCellWrapper join(int... columnIndexes);
+  }
+
+  public interface HeaderCellWrapper extends GridStylesHelper, RmiRemote { }
+
+  HeaderRowWrapper getRow(int rowIndex);
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeaderFooterStylesIT.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeaderFooterStylesIT.java
@@ -1,0 +1,64 @@
+/*-
+ * #%L
+ * Grid Helpers Add-on
+ * %%
+ * Copyright (C) 2022 - 2025 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.gridhelpers.it;
+
+import static org.junit.Assert.assertEquals;
+import com.flowingcode.vaadin.addons.gridhelpers.it.HeaderFooterStylesCallables.HeaderRowWrapper;
+import com.flowingcode.vaadin.testbench.rpc.HasRpcSupport;
+import com.vaadin.flow.component.grid.testbench.GridElement;
+import org.junit.Test;
+
+
+public class HeaderFooterStylesIT extends AbstractViewTest implements HasRpcSupport {
+
+  HeaderFooterStylesCallables $server = createCallableProxy(HeaderFooterStylesCallables.class);
+
+  GridHelperElement grid;
+
+  public HeaderFooterStylesIT() {
+    super(HeaderFooterStylesView.ROUTE);
+  }
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+    grid = new GridHelperElement($(GridElement.class).waitForFirst());
+  }
+
+  @Test
+  public void testHeaderVisible() {
+    HeaderRowWrapper row0 = $server.getRow(0);
+    row0.join(0, 1).setClassName("row0-cell0");
+    row0.join(2, 3).setClassName("row0-cell1");
+
+    HeaderRowWrapper row1 = $server.getRow(1);
+    for (int i = 0; i < 5; i++) {
+      row1.getCell(i).setClassName("row1-cell" + i);
+    }
+
+    assertEquals("row0-cell0", grid.getHeaderCell(0, 0).getAttribute("class"));
+    assertEquals("row0-cell1", grid.getHeaderCell(0, 1).getAttribute("class"));
+
+    for (int i = 0; i < 5; i++) {
+      assertEquals("row1-cell" + i, grid.getHeaderCell(1, i).getAttribute("class"));
+    }
+  }
+
+}

--- a/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeaderFooterStylesView.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/gridhelpers/it/HeaderFooterStylesView.java
@@ -1,0 +1,111 @@
+/*-
+ * #%L
+ * Grid Helpers Add-on
+ * %%
+ * Copyright (C) 2022 - 2025 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.gridhelpers.it;
+
+import com.flowingcode.vaadin.addons.gridhelpers.GridHelper;
+import com.flowingcode.vaadin.addons.gridhelpers.GridStylesHelper;
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.grid.Grid.Column;
+import com.vaadin.flow.component.grid.HeaderRow;
+import com.vaadin.flow.component.grid.HeaderRow.HeaderCell;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+import elemental.json.JsonObject;
+import elemental.json.JsonValue;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Delegate;
+import lombok.experimental.ExtensionMethod;
+
+@SuppressWarnings("serial")
+@Route(HeaderFooterStylesView.ROUTE)
+@ExtensionMethod(GridHelper.class)
+public class HeaderFooterStylesView extends Div implements HeaderFooterStylesCallables {
+
+  public static final String ROUTE = "it/styles";
+
+  private Grid<Integer> grid;
+
+  public HeaderFooterStylesView() {
+    setSizeFull();
+    getElement().getStyle().set("flex-grow", "1");
+    grid = new Grid<>();
+    for (int i = 0; i < 5; i++) {
+      grid.addColumn(x -> x).setHeader("col " + i);
+    }
+    grid.prependHeaderRow();
+    add(grid);
+  }
+
+  @Override
+  @ClientCallable
+  public JsonValue $call(JsonObject invocation) {
+    return HeaderFooterStylesCallables.super.$call(invocation);
+  }
+
+
+  @RequiredArgsConstructor
+  private abstract class StylesWrapper {
+    @Delegate
+    private final GridStylesHelper styles;
+  }
+
+  private final class HeaderCellWrapperImpl extends StylesWrapper implements HeaderCellWrapper {
+    public HeaderCellWrapperImpl(GridStylesHelper styles) {
+      super(styles);
+    }
+  }
+
+  private final class HeaderRowWrapperImpl extends StylesWrapper implements HeaderRowWrapper {
+    private final HeaderRow row;
+
+    public HeaderRowWrapperImpl(HeaderRow row) {
+      super(GridHelper.getHeaderStyles(grid, row));
+      this.row = row;
+    }
+
+    @Override
+    public HeaderCellWrapper getCell(int columnIndex) {
+      HeaderCell cell = row.getCell(grid.getColumns().get(columnIndex));
+      return new HeaderCellWrapperImpl(grid.getHeaderStyles(cell));
+    }
+
+    @Override
+    public HeaderCellWrapper join(int... columnIndexes) {
+      HeaderCell cell = row.join(IntStream.of(columnIndexes)
+        .mapToObj(grid.getColumns()::get)
+        .toArray(Column[]::new));
+      cell.setText("join " + IntStream.of(columnIndexes)
+        .mapToObj(Integer::toString)
+        .collect(Collectors.joining()));
+      return new HeaderCellWrapperImpl(GridHelper.getHeaderStyles(grid, cell));
+    }
+
+  }
+
+  @Override
+  public HeaderRowWrapper getRow(int rowIndex) {
+    HeaderRow row = grid.getHeaderRows().get(rowIndex);
+    return new HeaderRowWrapperImpl(row);
+  }
+
+}


### PR DESCRIPTION
Close #134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved grid column index calculation to treat consecutive identical cells as a single step, fixing header/footer selection and joined-column behavior.
  - More reliable application of CSS classes to specific header cells.

- Tests
  - Added integration tests validating header styling across multiple rows and columns.
  - Added test helpers and remote-callable test contracts to access header rows/cells and verify applied classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->