### PR TITLE
Add a managed dependency for kubernetes-kit-starter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<url>https://www.flowingcode.com/en/open-source/</url>
 
 	<properties>
-		<vaadin.version>23.3.15</vaadin.version>
+		<vaadin.version>23.3.35</vaadin.version>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
             <dependency>
             	<groupId>com.flowingcode.vaadin.addons.demo</groupId>
             	<artifactId>commons-demo</artifactId>
-            	<version>3.8.0</version>
+            	<version>3.10.0</version>
             </dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
 				<scope>import</scope>
 				<version>${vaadin.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>com.vaadin</groupId>
+				<artifactId>kubernetes-kit-starter</artifactId>
+				<version>1.0.0</version>
+			</dependency>
             <dependency>
             	<groupId>com.flowingcode.vaadin.addons.demo</groupId>
             	<artifactId>commons-demo</artifactId>


### PR DESCRIPTION
The Vaadin 23.3 BOM includes a managed dependency for `kubernetes-kit-starter:1.0-SNAPSHOT`. This, in turn, gets inherited by the project's effective POM as a managed dependency. Consequently, Maven Central rejects the build because it does not allow releases to have SNAPSHOT **_managed_** dependencies, even if the dependency isn't directly used in the project.

See https://github.com/FlowingCode/AddonsInternal/issues/111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded the underlying UI framework version, delivering stability and compatibility improvements.
  * Updated demo-related components to a newer version, aligning with recent enhancements and fixes.
  * Added Kubernetes integration capability via a new starter, improving deployment and operational robustness for Kubernetes environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->