### PR TITLE
build: upgrade vaadin to 23.3.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	<url>https://www.flowingcode.com/en/open-source/</url>
 
 	<properties>
-		<vaadin.version>23.3.15</vaadin.version>
+		<vaadin.version>23.3.35</vaadin.version>
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Upgrade vaadin to 23.3.35 in order to get rid of a managed dependency to `kubernetes-kit-starter:1.0-SNAPSHOT` (that was actually fixed in 23.3.17, but since 23.3 has already reached EOL, let's use the last release)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Upgraded Vaadin framework to version 23.3.35 to align with the latest maintenance release.
  * Includes upstream security patches, compatibility improvements, and minor performance/stability enhancements.
  * Reduces dependency conflicts and ensures smoother builds across environments.
  * No functional or UI changes expected; existing features should behave as before.
  * No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->