### PR TITLE
fix: Use Uses instead of NpmPackage to avoid version conflicts

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridRadioSelectionColumn.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridRadioSelectionColumn.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.dependency.Uses;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridRadioSelectionColumn.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridRadioSelectionColumn.java
@@ -21,6 +21,7 @@
 package com.flowingcode.vaadin.addons.gridhelpers;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridRadioSelectionColumn.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridRadioSelectionColumn.java
@@ -33,10 +33,11 @@ import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
  * Server side implementation for the flow specific grid radio selection column.
  */
 @Tag("grid-flow-radio-selection-column")
-@NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "24.3.2")
 @JsModule("@vaadin/polymer-legacy-adapter/style-modules.js")
 @JsModule("./fcGridHelper/grid-flow-radio-selection-column.js")
 @Uses(RadioButtonGroup.class)
+// Indirectly ensure @NpmPackage(value = "@vaadin/polymer-legacy-adapter", version = "x.x.x")
+@Uses(Grid.class)
 public class GridRadioSelectionColumn extends Component implements HasStyle {
 
   /**


### PR DESCRIPTION
Updated NpmPackage annotation to ensure compatibility with the latest version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Ensures grid resources are correctly included, preventing runtime issues with the radio selection column.

- Performance
  - Slightly reduces bundle size by removing an unnecessary legacy dependency.

- Chores
  - Updated internal annotations/dependency usage to align with platform conventions and improve compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->