### PR TITLE
refactor: remove use of lang3 trimToNull

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelperClassNameGenerator.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/GridHelperClassNameGenerator.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.commons.lang3.StringUtils;
 
 @SuppressWarnings("serial")
 final class GridHelperClassNameGenerator<T> implements SerializableFunction<T, String> {

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/HeaderFooterStylesHelper.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/HeaderFooterStylesHelper.java
@@ -42,7 +42,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.experimental.Delegate;
-import org.apache.commons.lang3.StringUtils;
 
 @SuppressWarnings("serial")
 @RequiredArgsConstructor

--- a/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/StringUtils.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/gridhelpers/StringUtils.java
@@ -1,0 +1,68 @@
+/*-
+ * #%L
+ * Grid Helpers Add-on
+ * %%
+ * Copyright (C) 2022 - 2025 Flowing Code
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.flowingcode.vaadin.addons.gridhelpers;
+
+import lombok.experimental.UtilityClass;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+@UtilityClass
+class StringUtils {
+
+  /**
+   * Removes control characters from both ends of this String returning {@code null} if the String
+   * is empty ("") after the trim or if it is {@code null}.
+   *
+   * <pre>
+   * StringUtils.trimToNull(null)          = null
+   * StringUtils.trimToNull("")            = null
+   * StringUtils.trimToNull("     ")       = null
+   * StringUtils.trimToNull("abc")         = "abc"
+   * StringUtils.trimToNull("    abc    ") = "abc"
+   * </pre>
+   *
+   * @param str the String to be trimmed, may be null
+   * @return the trimmed String, {@code null} if only chars &lt;= 32, empty or null String input
+   */
+  static String trimToNull(String str) {
+    if (str == null) {
+      return null;
+    }
+    str = str.trim();
+    if (str.isEmpty()) {
+      return null;
+    }
+    return str;
+  }
+
+}


### PR DESCRIPTION
Close #149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an internal string-trimming utility and removed reliance on an external string-utils import.
  * Internal cleanup to centralize trimming behavior; no API or user-facing changes expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->